### PR TITLE
Generate NFData instances

### DIFF
--- a/data-sword.cabal
+++ b/data-sword.cabal
@@ -1,5 +1,5 @@
 Name: data-sword
-Version: 0.2.0.3
+Version: 0.2.0.4
 Category: Data
 Stability: experimental
 Synopsis: Shorter binary words
@@ -37,6 +37,7 @@ Library
                , template-haskell
                , hashable >= 1.1
                , data-bword >= 0.1
+               , deepseq >= 1.4
   Hs-Source-Dirs: src
   GHC-Options: -Wall
   Exposed-Modules:
@@ -47,6 +48,7 @@ Test-Suite tests
   Default-Language: Haskell2010
   Type: exitcode-stdio-1.0
   Build-Depends: base
+               , deepseq >= 1.4
                , tasty >= 0.8
                , tasty-quickcheck >= 0.8
                , data-sword

--- a/src/Data/ShortWord/TH.hs
+++ b/src/Data/ShortWord/TH.hs
@@ -7,6 +7,7 @@ module Data.ShortWord.TH
   ( mkShortWord
   ) where
 
+import Control.DeepSeq (NFData (..))
 import GHC.Arr (Ix(..))
 import GHC.Enum (succError, predError, toEnumError)
 import Data.Data
@@ -79,6 +80,9 @@ mkShortWord' signed tp cn pn otp ocn utp bl ad = returnDecls $
 #endif
     , SigD pn (AppT (ConT ''Proxy) tpT)
     , fun pn $ ConE 'Proxy
+    , inst ''NFData [tp]
+        [ funUn 'rnf $ appVN 'rnf [x]
+        , inline 'rnf ]
     , inst ''Eq [tp] $
         {- (W x) == (W y) = x == y -}
         [ funUn2 '(==) $ appVN '(==) [x, y]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -9,6 +9,7 @@
 import Test.Tasty (defaultMain, localOption, testGroup)
 import Test.Tasty.QuickCheck hiding ((.&.))
 
+import Control.DeepSeq (rnf)
 import Data.Bits
 import Data.Word
 import Data.Int
@@ -39,6 +40,7 @@ main = defaultMain
 isoTestGroup name t =
   testGroup name
     [ testProperty "Iso" $ prop_conv t
+    , testGroup "NFData" [ testProperty "rnf" $ prop_rnf t ]
     , testGroup "Eq" [ testProperty "(==)" $ prop_eq t ]
     , testGroup "Ord" [ testProperty "compare" $ prop_compare t ]
     , testGroup "Bounded"
@@ -116,6 +118,8 @@ propBinary f g t w1 w2 = isValid r && f w1 w2 == toArbitrary r
 propBinary' f g t w1 w2 = f w1 w2 == withBinary t g w1 w2
 
 prop_conv t w = toArbitrary (toType t w) == w
+
+prop_rnf = rnf
 
 prop_eq = propBinary' (==) (==)
 


### PR DESCRIPTION
This PR adds [NFData](https://hackage.haskell.org/package/deepseq-1.4.8.1/docs/Control-DeepSeq.html#t:NFData) instances to short word types. These instances only defer to the `NFData` instance of the wrapped type. This change makes it possible to derive `NFData` for record types that have short word fields.